### PR TITLE
ARS-4919 [Node-ACS-Test] Publishing container to ARS hanging

### DIFF
--- a/ARS.md
+++ b/ARS.md
@@ -1,0 +1,54 @@
+
+# Overview
+
+* Design
+  * https://techweb.axway.com/confluence/display/cls/Harbor+1.10.1+Integration
+
+* Tickets
+  * https://jira.axway.com/browse/ARS-4435
+  * https://jira.axway.com/browse/ARS-4543
+
+
+
+# Build docker image for harbor-core
+
+## Build the base image for harbor-core
+
+    make build_base_docker_core -e BASEIMAGETAG=4435
+
+Note: Specify BASEIMAGETAG as appropriate
+
+## Build harbor-core image
+
+    make compile_core
+    make build_core -e BASEIMAGETAG=4435 -e VERSIONTAG=3a1d857
+
+## Push harbor-core image
+
+    make pushimage_core -e VERSIONTAG=3a1d857 -e REGISTRYUSER=xxx -e REGISTRYPASSWORD=xxx
+
+Note: You can push it manually.
+
+Note: git commit for the custom build targets: https://github.com/appcelerator/harbor/commit/f4c16ff341edc94f1af4e3b557f051ba1522880e
+
+
+# Build docker image for harbor-jobservice
+
+## Build the base image for harbor-core
+
+    make build_base_docker_jobservice -e BASEIMAGETAG=4543
+
+Note: Specify BASEIMAGETAG as appropriate
+
+## Build harbor-core image
+
+    make compile_jobservice
+    make build_jobservice -e BASEIMAGETAG=4543 -e VERSIONTAG=d3c25c3
+
+## Push harbor-core image
+
+    make pushimage_jobservice -e VERSIONTAG=d3c25c3 -e REGISTRYUSER=xxx -e REGISTRYPASSWORD=xxx
+
+Note: You can push it manually.
+
+Note: git commit for the custom build targets: https://github.com/appcelerator/harbor/commit/7cdd0e1f5dea616e91af08faa318a97ab384a68d

--- a/src/core/auth/ars/accesstoken.go
+++ b/src/core/auth/ars/accesstoken.go
@@ -259,7 +259,7 @@ func checkAuthResponse(resp *http.Response, accessToken string) (user *models.Us
 		return
 	}
 
-	user = createUserObject(jsonBody, sid, getDegest(accessToken))
+	user = createUserObject(jsonBody, sid, getDigest(accessToken))
 
 	return
 }

--- a/src/core/auth/ars/accesstoken.go
+++ b/src/core/auth/ars/accesstoken.go
@@ -215,11 +215,11 @@ func authenticateByToken(m models.AuthModel) (*models.User, error) {
 		return nil, err
 	}
 
-	return checkAuthResponse(resp)
+	return checkAuthResponse(resp, accessToken)
 }
 
 // check the response of authentication request
-func checkAuthResponse(resp *http.Response) (user *models.User, err error) {
+func checkAuthResponse(resp *http.Response, accessToken string) (user *models.User, err error) {
 
 	if resp.StatusCode != 200 {
 		err = fmt.Errorf("failed to authenticate with token against dashboard. response code %v", resp.StatusCode)
@@ -259,7 +259,7 @@ func checkAuthResponse(resp *http.Response) (user *models.User, err error) {
 		return
 	}
 
-	user = createUserObject(jsonBody, sid)
+	user = createUserObject(jsonBody, sid, getDegest(accessToken))
 
 	return
 }

--- a/src/core/auth/ars/dashboard.go
+++ b/src/core/auth/ars/dashboard.go
@@ -238,7 +238,7 @@ func authenticateByPassword(m models.AuthModel) (*models.User, error) {
 func createUserObject(userData *gabs.Container, sid string) *models.User {
 
 	// use Realname field to save dashboard session and Salt for the realname.
-	// The realname will be set back in PostAuthenticate. No other unused fields (including Salt) are long enough for sid.
+	// No other unused fields (including Salt) are long enough for sid.
 	mUser := &models.User{
 		Username: userData.Path("result.username").Data().(string),
 		Realname: sid,
@@ -265,6 +265,7 @@ func createUserObject(userData *gabs.Container, sid string) *models.User {
 		lastName = userData.Path("result.user.lastname").Data().(string)
 	}
 
+	// Realname is used for saving dashboard session
 	mUser.Salt = firstName + " " + lastName
 
 	// "role": "administrator"
@@ -315,11 +316,8 @@ func (d *Auth) PostAuthenticate(user *models.User) error {
 		return err
 	}
 
-	// get dashboardsid and set back Realname from Salt
-	// workaround for carring the sid here
+	// need to save dashboardsid in user.Realname as it's the only field long enough
 	dashboardSid := user.Realname
-	user.Realname = user.Salt
-	user.Salt = ""
 
 	var cachedUserOrg *models.UserOrg
 	refreshOrgs := false

--- a/src/core/auth/ars/dashboard.go
+++ b/src/core/auth/ars/dashboard.go
@@ -69,7 +69,7 @@ func (d *Auth) Authenticate(m models.AuthModel) (*models.User, error) {
 			return authenticateByPassword(m)
 		}
 
-		return existing
+		return existing, nil
 
 	}
 

--- a/src/core/auth/ars/dashboard.go
+++ b/src/core/auth/ars/dashboard.go
@@ -1,7 +1,7 @@
 package ars
 
 import (
-	"crypto/sha256"
+	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -456,7 +456,7 @@ func getDegest(value string) string {
 	// The pattern for generating a hash is `sha1.New()`,
 	// `sha1.Write(bytes)`, then `sha1.Sum([]byte{})`.
 	// Here we start with a new hash.
-	h := sha256.New()
+	h := sha1.New()
 
 	// `Write` expects bytes. If you have a string `s`,
 	// use `[]byte(s)` to coerce it to bytes.

--- a/src/core/auth/ars/dashboard.go
+++ b/src/core/auth/ars/dashboard.go
@@ -332,7 +332,8 @@ func (d *Auth) PostAuthenticate(user *models.User) error {
 		user.UserID = dbUser.UserID
 		user.HasAdminRole = dbUser.HasAdminRole
 		fillEmailRealName(user)
-		if err2 := dao.ChangeUserProfile(*user, "Email", "Realname"); err2 != nil {
+		// Password field is used for saving the time authentication happening
+		if err2 := dao.ChangeUserProfile(*user, "Email", "Realname", "Password"); err2 != nil {
 			log.Warningf("Failed to update user profile, user: %s, error: %v", user.Username, err2)
 		}
 
@@ -343,6 +344,8 @@ func (d *Auth) PostAuthenticate(user *models.User) error {
 		}
 
 		// TODO show cachedUserOrg.UpdateTime
+		log.Debugf("cachedUserOrg.UpdateTime: %v", cachedUserOrg.UpdateTime)
+
 		if cachedUserOrg == nil {
 			log.Warningf("No cached organization info found for user %s", user.Username)
 			refreshOrgs = true
@@ -392,8 +395,8 @@ func (d *Auth) PostAuthenticate(user *models.User) error {
 
 	// TODO set updateTime
 	mUserOrg := &models.UserOrg{
-		UserID: user.UserID,
-		Orgs:   string(jsonOrgs),
+		UserID:     user.UserID,
+		Orgs:       string(jsonOrgs)
 	}
 
 	oldOrgs := map[string]Org{}

--- a/src/core/auth/ars/dashboard.go
+++ b/src/core/auth/ars/dashboard.go
@@ -395,8 +395,8 @@ func (d *Auth) PostAuthenticate(user *models.User) error {
 
 	// TODO set updateTime
 	mUserOrg := &models.UserOrg{
-		UserID:     user.UserID,
-		Orgs:       string(jsonOrgs)
+		UserID: user.UserID,
+		Orgs:   string(jsonOrgs),
 	}
 
 	oldOrgs := map[string]Org{}


### PR DESCRIPTION
# Ticket
https://jira.axway.com/browse/ARS-4919
# Description
Sending too many auth requests to Dashboard causes Dashboard invalidating older sessions which includes the one for Stratus. It results in a user being asked to login again after pushing the image for a brand new app is pushed to the in-cluster registry.
* don't send auth request to Dashboard each time, instead,
* save a hash digest of a user's password in the database and use it to check for auth. Send an auth request to Dashboard only when
  * the last auth against Dashboard happened 10 mins ago (configurable via env var USER_SESSION_DURATION)
  * user provides a different password
# Test
make sure that the following test passes
* publish app from docker image

when run 
```
node run --hostname https://admin.spectest.jin.apirs.net --user xxx --password xxx --environment enterprise --orgid 100007996 --suite cli --testName publish.js
```

