### PR TITLE
ARS-5098 Add dual domain support to harbor

### DIFF
--- a/src/core/auth/ars/organizations.go
+++ b/src/core/auth/ars/organizations.go
@@ -163,7 +163,7 @@ func checkOrgs(orgArray []interface{}) (orgs map[string]Org, haveAccess bool) {
 	thisEnvHost := re.ReplaceAllString(thisEnvAdminURL, "")
 	thisEnv2ndHost := re.ReplaceAllString(thisEnv2ndAdminURL, "")
 
-	log.Debugf("check if user's organizations have access to this domain: %s", thisEnvHost)
+	log.Debugf("check if user's organizations have access to this domain: %s and %s", thisEnvHost, thisEnv2ndHost)
 
 	orgs = map[string]Org{} //organizations which can access this domain (deployment)
 	userOrgIds := []string{}

--- a/src/core/auth/ars/organizations.go
+++ b/src/core/auth/ars/organizations.go
@@ -159,7 +159,9 @@ func checkOrgs(orgArray []interface{}) (orgs map[string]Org, haveAccess bool) {
 
 	re := regexp.MustCompile("^(http|https)://") //https://golang.org/pkg/regexp/#MustCompile
 	thisEnvAdminURL := os.Getenv("ADMIN_URL")
+	thisEnv2ndAdminURL := os.Getenv("APPC_ADMIN_URL")
 	thisEnvHost := re.ReplaceAllString(thisEnvAdminURL, "")
+	thisEnv2ndHost := re.ReplaceAllString(thisEnv2ndAdminURL, "")
 
 	log.Debugf("check if user's organizations have access to this domain: %s", thisEnvHost)
 
@@ -208,7 +210,7 @@ func checkOrgs(orgArray []interface{}) (orgs map[string]Org, haveAccess bool) {
 					re := regexp.MustCompile("^(http|https)://")
 					adminHost := re.ReplaceAllString(adminHost, "")
 					log.Debugf("org %s(%s) have access to %s", orgToSave.Name, orgToSave.ID, adminHost)
-					if adminHost == thisEnvHost {
+					if adminHost == thisEnvHost || adminHost == thisEnv2ndHost {
 						orgs[orgToSave.ID] = orgToSave
 						break
 					}


### PR DESCRIPTION
# Ticket
https://jira.axway.com/browse/ARS-5098
# Description
updated to give permission to organizations that have access to either the new domain or the old domain of a cluster
# Test
verify that you can push images to all organizations having access to the old (appc) domain